### PR TITLE
New blog post link on how to set up CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Using OPA on EKS](https://aws.amazon.com/blogs/opensource/using-open-policy-agent-on-amazon-eks/) - Using Open Policy Agent on Amazon EKS
 - [OPA and Gatekeeper](https://www.infracloud.io/blogs/opa-and-gatekeeper/) - Comparison between OPA and Gatekeeper with lots of useful information
 - [Kubernetes Authorization](https://itnext.io/kubernetes-authorization-via-open-policy-agent-a9455d9d5ceb) - Guide on using OPA for Kubernetes authorization
+- [Gatekeeper in a CI/CD pipeline](https://arapulido.github.io/blog/2021/08/02/testing-your-kubernetes-config-against-policy-ci/) - Guide on how to setup your CI environment to test your Kubernetes configuration against your policy in a CI environment as part of a GitOps strategy
 
 ## Datasource Integrations
 


### PR DESCRIPTION
Adding a blog post around how to setup your CI environment to test your Kubernetes configuration against your policy in a CI environment as part of a GitOps strategy