### PR TITLE
README.md: fix link to Go SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [NPM module](https://github.com/open-policy-agent/npm-opa-wasm/) - a small SDK for using WebAssembly compiled Open Policy Agent Rego policies
 - [.NET Core Library](https://github.com/christophwille/csharp-opa-wasm) - .NET SDK for calling Wasm-compiled OPA policies from .NET Core
 - [Python Library](https://github.com/a2d24/python-opa-wasm) - Open Policy Agent WebAssembly SDK for Python
-- [Go SDK](https://github.com/open-policy-agent/golang-opa-wasm) - a small Go library for using WebAssembly compiled Open Policy Agent Rego policies
+- [Go SDK](https://github.com/open-policy-agent/opa/tree/main/internal/wasm/sdk) - a small Go library for using WebAssembly compiled Open Policy Agent Rego policies
 - [JVM](https://github.com/sangkeon/java-opa-wasm) - Java SDK for calling Wasm-compiled policies. Uses wasmtime.
 
 ### Docs


### PR DESCRIPTION
Go SDK have been moved to another location:
https://github.com/open-policy-agent/opa/tree/main/internal/wasm/sdk

Signed-off-by: jun.gu <jun.gu@easystack.cn>